### PR TITLE
docs: align Slite MCP usage (CLI slite-mcp, package slite-mcp-server)…

### DIFF
--- a/.github/instructions/repo.instruction.md
+++ b/.github/instructions/repo.instruction.md
@@ -112,3 +112,34 @@ PR checklist (docs):
 - [ ] Updated root `README.md` (Quickstart, Endpoints, Notes, links)
 - [ ] Updated project-level READMEs if public behavior or responsibilities changed
 - [ ] Updated `configs/README.md` if adding new agent configs or patterns
+
+## Testing (keep tests in sync with behavior)
+
+Test projects live under `tests/` and cover each component:
+- `Agent.Core.Tests` – config defaults, DTOs, serialization
+- `Agent.Mcp.Tests` – JSON-RPC parsing and transport heuristics
+- `Agent.Providers.Tests` – provider request/response handling (mock + real API parsing via fake handlers)
+- `Agent.Template.Tests` – API surface using WebApplicationFactory (health, basic endpoint contracts)
+
+Run all tests locally:
+```
+dotnet test agent-smith.sln
+```
+
+When to update tests:
+- If you change HTTP endpoints (paths, request/response contract, status codes) → update `Agent.Template.Tests` and docs
+- If you change `Agent.Core` config/DTOs (names, defaults, JSON shape) → update `Agent.Core.Tests`
+- If you change MCP transport parsing or protocol handling → update `Agent.Mcp.Tests`
+- If you add/modify a provider (payloads, headers, parsing) → add/update tests in `Agent.Providers.Tests`
+
+Patterns used in tests:
+- API tests use `WebApplicationFactory<Agent.Template.ProgramMarker>` to boot the minimal API
+- Provider tests inject a custom `HttpMessageHandler` into `GitHubModelsProvider` to simulate responses
+- MCP parsing tests validate internal heuristics via reflection against private parsing helpers
+
+PR checklist (tests):
+- [ ] All tests pass locally (`dotnet test`)
+- [ ] New/changed behaviors are covered by unit tests
+- [ ] Provider changes include parsing/error-path tests (use fake `HttpMessageHandler`)
+- [ ] Endpoint changes include WebApplicationFactory tests
+- [ ] Config/DTO changes include serialization/defaults tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # agent-smith
-AI agent template (.NET 8) with MCP connectivity (Streamable HTTP + stdio) and an OpenAI-style chat API.
+AI agent template (.NET 8) that exposes an OpenAI-style chat API and connects to Model Context Protocol (MCP) servers over stdio or streamable HTTP (SSE). It’s config-driven (one JSON per agent), containerized (one image per config), and includes diagnostics to list/call MCP tools for easy integration testing.
+
+## Features
+- OpenAI-style POST /v1/chat (non-streaming) with a configurable persona/system prompt
+- Config-driven agents (JSON under `configs/`) with `${VAR}` environment substitution
+- MCP connectivity via:
+	- stdio (e.g., `npx slite-mcp`) with cancellable reads to avoid hangs
+	- streamable HTTP with SSE parsing and JSON-RPC handling
+- Provider abstraction with:
+	- GitHub Models (real) using `GITHUB_MODELS_TOKEN`
+	- Mock provider for local/offline development
+- Diagnostics endpoints to validate MCP wiring without the model:
+	- `GET /mcp/tools` and `POST /mcp/call`
+- Container-first: one image per config via build args; Docker Compose services per agent
+- Health checks and pragmatic timeouts for stable local and container runs
+- CI workflow for build/test and image builds (ECR push scaffolded)
 
 ## Quickstart
 
@@ -36,6 +51,8 @@ Option B: with config
 - GET / -> service heartbeat
 - GET /healthz -> health
 - POST /v1/chat -> OpenAI-style chat (non-streaming)
+ - GET /mcp/tools -> list MCP tools (diagnostic)
+ - POST /mcp/call -> call an MCP tool by name (diagnostic)
 
 Request body:
 { "messages": [{ "role": "user", "content": "Hello" }] }
@@ -46,7 +63,7 @@ Response body:
 ## Configuration
 - Persona/system prompt and provider parameters in JSON (see `configs/`)
 - MCP:
-	- stdio: uses Node/npm; for Slite the package is `slite-mcp-server`
+	- stdio: uses Node/npm; for Slite the npm package is `slite-mcp-server` (CLI name: `slite-mcp`)
 	- streamable-http: supports SSE response parsing
 
 ## Notes
@@ -56,3 +73,86 @@ Response body:
 
 See also:
 - docs/slite-onboarding.md for Slite MCP setup/testing
+
+## Add a new agent
+
+You can add a new agent either manually or by asking GitHub Copilot to do it for you.
+
+Manual steps:
+1) Create a config: copy any file in `configs/` (e.g., `slite.agent.json`) to `configs/<your>.agent.json` and edit:
+	- `agent`: name and `systemPrompt`
+	- `model`: provider and `modelId` (env override via `MODEL_PROVIDER` is supported)
+	- `mcp` (choose one):
+	  - stdio: set `command` (e.g., `npx`) and `args` (e.g., `["-y","<your-mcp-server>"]`), plus any `env` like `${YOUR_API_KEY}`
+	  - streamable-http: set `http.url`, and optionally `allowSse` and `timeoutMs`
+	- `runtime.port`: internal port (container listens on 8080; host port is set in compose)
+2) Wire it in Docker Compose: add a service to `docker/docker-compose.yml` using the same Dockerfile with `build.args.CONFIG_FILE: configs/<your>.agent.json`, set a unique host port mapping (e.g., `8083:8080`), include `env_file: ../.env`, and set `AGENT_CONFIG_PATH=/app/config/agent.json` in `environment`.
+3) Update `.env`: add any required secrets referenced by your config (e.g., `YOUR_API_KEY`), plus `GITHUB_MODELS_TOKEN` for real model calls.
+4) (Optional) Warm up npm-based stdio MCP servers once to avoid first-run delays:
+	- `npx -y <your-mcp-server> --help`
+5) Rebuild and run:
+	- `docker compose -f docker/docker-compose.yml up -d --build`
+6) Test:
+	- Health: `curl http://localhost:<your-host-port>/healthz`
+	- Chat: `POST /v1/chat` with a messages array
+	- MCP diagnostics (if applicable): `GET /mcp/tools` and `POST /mcp/call`
+
+Ask GitHub Copilot to add it for you:
+- Tell GitHub Copilot: the MCP type (stdio vs streamable-http), server command/URL, any required env vars, the desired host port, and provider/model settings. It will create the config, update compose, and validate with health and chat calls.
+
+More details:
+- See `.github/instructions/repo.instruction.md` for architecture and MCP server guidance
+
+## Testing
+
+Docker Compose (recommended):
+
+1) Ensure `.env` is configured (tokens/secrets and any MCP vars)
+2) Start services
+```bash
+docker compose -f docker/docker-compose.yml up -d --build
+```
+3) Health checks
+```bash
+curl -sS http://localhost:8081/healthz | jq .    # slite
+curl -sS http://localhost:8082/healthz | jq .    # newrelic
+```
+4) Chat test (slite)
+```bash
+curl -m 30 -sS -X POST http://localhost:8081/v1/chat \
+	-H 'Content-Type: application/json' \
+	-d '{"messages":[{"role":"user","content":"Say hi"}]}' | jq .
+```
+5) MCP diagnostics (slite)
+```bash
+curl -sS http://localhost:8081/mcp/tools | jq .
+curl -sS -X POST http://localhost:8081/mcp/call \
+	-H 'Content-Type: application/json' \
+	-d '{"name":"ask-slite","arguments":{"question":"What are my last 3 notes?"}}' | jq .
+```
+
+Mock vs real provider:
+- Fast local: set `MODEL_PROVIDER=mock` and optionally `SKIP_MCP_INIT=true` in `.env`, rebuild, then call `/v1/chat`.
+- Real model: set `MODEL_PROVIDER=github-models`, ensure `GITHUB_MODELS_TOKEN` is set, and keep `SKIP_MCP_INIT=false` for MCP.
+
+Slite stdio warm-up (avoids first-run delays):
+```bash
+set -a; source .env; set +a
+SLITE_API_KEY="$SLITE_API_KEY" npx -y slite-mcp --help >/dev/null 2>&1 || true
+```
+
+Local (without Docker):
+```bash
+ASPNETCORE_URLS=http://localhost:8080 \
+	AGENT_CONFIG_PATH=$PWD/configs/slite.agent.json \
+	dotnet run --project src/Agent.Template/Agent.Template.csproj
+
+# In another terminal
+curl -sS http://localhost:8080/healthz | jq .
+curl -sS -X POST http://localhost:8080/v1/chat \
+	-H 'Content-Type: application/json' \
+	-d '{"messages":[{"role":"user","content":"Say hi"}]}' | jq .
+```
+
+CI
+- Pull requests trigger build/test and Docker image builds (see `.github/workflows/ci.yml`).

--- a/configs/slite.agent.json
+++ b/configs/slite.agent.json
@@ -16,7 +16,7 @@
             "command": "npx",
             "args": [
                 "-y",
-                "slite-mcp-server"
+                "slite-mcp"
             ],
             "env": {
                 "SLITE_API_KEY": "${SLITE_API_KEY}"

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -15,12 +15,12 @@ This document captures the final decisions and a repeatable set of instructions 
   - No authentication for now; placeholders wired for future bearer auth.
 
 - MCP transports (to external MCP servers)
-  - Streamable HTTP: compliant with spec (Accept includes `application/json, text/event-stream`), supports SSE for POST responses. Also supports optional GET “listening” in v1.
+  - Streamable HTTP: compliant with spec (Accept includes `application/json, text/event-stream`), supports SSE for POST responses. Optional GET “listening” is deferred.
   - stdio: newline-delimited JSON-RPC; child process lifecycle handled by the agent.
   - Transport is selected via config per agent.
 
 - Slite MCP support
-  - Use stdio via Node-based `slite-mcp` (launched with `npx`).
+  - Use stdio via Node-based `slite-mcp` CLI (npm package: `slite-mcp-server`, launched with `npx`).
   - Node/npm included in the agent image for Slite builds.
 
 - Provider for LLM
@@ -67,7 +67,7 @@ agent-smith/
 │  └─ local-dev.md                  # docker-compose usage, curl examples
 │
 ├─ configs/
-│  ├─ slite.agent.json              # stdio to slite-mcp, persona + model
+│  ├─ slite.agent.json              # stdio to Slite MCP (CLI `slite-mcp`), persona + model
 │  ├─ newrelic.agent.json           # placeholder HTTP transport
 │  └─ samples/minimal.agent.json
 │
@@ -130,7 +130,7 @@ Minimal fields (JSON):
     },
     "stdio": {
       "command": "npx",
-      "args": ["-y", "slite-mcp"],
+  "args": ["-y", "slite-mcp"],
       "env": {
         "SLITE_API_KEY": "${SLITE_API_KEY}" // provided at runtime
       },
@@ -168,7 +168,7 @@ Example (Slite stdio):
     "transport": "stdio",
     "stdio": {
       "command": "npx",
-      "args": ["-y", "slite-mcp"],
+  "args": ["-y", "slite-mcp"],
       "env": { "SLITE_API_KEY": "${SLITE_API_KEY}" }
     }
   },
@@ -239,8 +239,8 @@ Example (New Relic placeholder / Streamable HTTP):
   - POST all client JSON-RPC messages to MCP endpoint.
   - Include `Accept: application/json, text/event-stream`.
   - Handle JSON responses or SSE event streams on POST.
-  - Support optional GET “listening” with `Accept: text/event-stream`.
-  - Handle `Mcp-Session-Id` header for sessions per spec.
+  - GET “listening” mode: deferred.
+  - `Mcp-Session-Id` session header: deferred (config placeholders exist).
 - stdio transport
   - Launch child process per config (e.g., `npx -y slite-mcp`).
   - JSON-RPC messages delimited by newlines; handle batches, cancellations, timeouts.
@@ -284,7 +284,7 @@ Example (New Relic placeholder / Streamable HTTP):
 
 - Do not commit secrets. Always pass tokens/keys via env or secret managers.
 - MCP Streamable HTTP security guidance recommends Origin checks and localhost binding for local servers. Placeholders are included; enable when needed.
-- SSE support is implemented for MCP compliance (POST responses and optional GET listening). The agent’s public API remains non-streaming in v1.
+- SSE support is implemented for MCP compliance (POST responses; GET listening deferred). The agent’s public API remains non-streaming in v1.
 
 ---
 

--- a/docs/mcp-transport.md
+++ b/docs/mcp-transport.md
@@ -2,8 +2,8 @@
 
 - Streamable HTTP
   - POST with Accept: application/json, text/event-stream; handle JSON or SSE responses.
-  - Optional GET listening with Accept: text/event-stream (v1 supported).
-  - Mcp-Session-Id header supported.
+  - GET listening with Accept: text/event-stream — deferred (not implemented yet).
+  - Mcp-Session-Id session header — deferred (placeholders only).
 
 - stdio
   - Launch child process (e.g., npx -y slite-mcp), communicate via newline-delimited JSON-RPC.


### PR DESCRIPTION
…; mark MCP HTTP GET listening and session header as deferred; update configs and warm-up commands