### PR TITLE
fix(docker): restore only web csproj in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ COPY src/Agent.Core/Agent.Core.csproj src/Agent.Core/
 COPY src/Agent.Mcp/Agent.Mcp.csproj src/Agent.Mcp/
 COPY src/Agent.Providers/Agent.Providers.csproj src/Agent.Providers/
 COPY src/Agent.Template/Agent.Template.csproj src/Agent.Template/
-RUN dotnet restore agent-smith.sln
+RUN dotnet restore src/Agent.Template/Agent.Template.csproj
 
 # build
 COPY . ./


### PR DESCRIPTION
Problem
Docker image build on main failed during `dotnet restore agent-smith.sln` because the Docker context copies only project csproj files under src/* for restore, and the solution references test projects under tests/* which aren’t present in the container at restore time.

Fix
Change Dockerfile restore step to:
- `dotnet restore src/Agent.Template/Agent.Template.csproj`
This restores only the web host project and its transitive dependencies, avoiding missing test csproj errors.

Notes
- Publish step already targets `src/Agent.Template/Agent.Template.csproj`.
- No functional code changes; container build is now resilient to absence of tests in the build context’s early restore stage.
